### PR TITLE
Synchronize settings between readme, init fnc and custom element

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,15 +86,8 @@ This implementation also supports **tracking changes in [linked content](https:/
 4. ### Run the index initialization 
     The initialization of your Algolia index with your content is done through the **algolia-init-function**. Simply make a POST request towards the function's endpoint URL with the following payload:
 
-    ```
-    {
-      "projectId": "{Kontent.ai project ID}",
-      "language": "{Kontent.ai language codename}",
-      "slugCodename": "{Kontent.ai slug codename}",
-      "algoliaAppId": "{Algolia app id}",
-      "algoliaIndexName": "{Algolia index name}"
-    }
-    ```
+    https://github.com/kontent-ai/integration-example-algolia/blob/074f1c02c9d13a3e290a9f75aa3d90a697a3ce0c/src/shared/constants/readmeSnippets.ts#L15-L21
+
     The function processes all **published** content from your project (based on the given ID) and creates or updates the search index in Algolia (again, based on the given parameter). 
     
     Alternatively, you can use the **custom element** that is a part of this repository as well. 
@@ -103,16 +96,8 @@ This implementation also supports **tracking changes in [linked content](https:/
 
     Use your netlify's URL for the base page as the **Hosted code URL** and a following settings to setup the custom element:
 
-    ```
-    {
-      "projectId": "{Kontent.ai project ID}",
-      "language": "{Kontent.ai language codename}",
-      "algoliaAppId": "{Algolia app id}",
-      "algoliaSearchKey": "{Algolia search-only api key}",
-      "algoliaIndexName": "{Algolia index name}",
-      "slugCodename": "{Kontent.ai slug codename}"
-    }
-    ```
+    https://github.com/kontent-ai/integration-example-algolia/blob/074f1c02c9d13a3e290a9f75aa3d90a697a3ce0c/src/shared/constants/readmeSnippets.ts#L6-L13
+
     The [Algolia's search-only api key](https://www.algolia.com/doc/guides/security/api-keys/#search-only-api-key) is used to preview the search functionality from within the custom element.
 
     The custom element allows you to (re)initialize your Algolia index with all of your content + offers a way to preview your search results. 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,6 @@ This implementation also supports **tracking changes in [linked content](https:/
       "language": "{Kontent.ai language codename}",
       "slugCodename": "{Kontent.ai slug codename}",
       "algoliaAppId": "{Algolia app id}",
-      "algoliaSearchKey": "{Algolia API key for search only},
       "algoliaIndexName": "{Algolia index name}"
     }
     ```
@@ -106,10 +105,12 @@ This implementation also supports **tracking changes in [linked content](https:/
 
     ```
     {
-    "algoliaAppId": "{Algolia app id}",
-    "algoliaSearchKey": "{Algolia search-only api key}",
-    "algoliaIndexName": "{Algolia index name}"
-    "slugCodename": "{Kontent.ai slug codename}",    
+      "projectId": "{Kontent.ai project ID}",
+      "language": "{Kontent.ai language codename}",
+      "algoliaAppId": "{Algolia app id}",
+      "algoliaSearchKey": "{Algolia search-only api key}",
+      "algoliaIndexName": "{Algolia index name}",
+      "slugCodename": "{Kontent.ai slug codename}"
     }
     ```
     The [Algolia's search-only api key](https://www.algolia.com/doc/guides/security/api-keys/#search-only-api-key) is used to preview the search functionality from within the custom element.

--- a/src/AlgoliaSync.tsx
+++ b/src/AlgoliaSync.tsx
@@ -1,5 +1,6 @@
 import { FC, useState } from 'react';
 import { useConfig } from './ConfigContext';
+import { InitRequestBody } from './shared/types/initRequestBody';
 
 const initFunctionUrl = '/.netlify/functions/algolia-init-function';
 
@@ -22,10 +23,10 @@ export const AlgoliaSync: FC<Props> = props => {
     const body = JSON.stringify({
       projectId: config.projectId,
       language: config.language,
-      slug: config.slugCodename,
-      appId: config.algoliaAppId,
-      index: config.algoliaIndexName,
-    });
+      slugCodename: config.slugCodename,
+      algoliaAppId: config.algoliaAppId,
+      algoliaIndexName: config.algoliaIndexName,
+    } satisfies InitRequestBody);
     setSynchronizationStatus(SynchronizationStatus.InProgress);
     fetch(initFunctionUrl, { method: 'POST', body })
       .then(() => {

--- a/src/functions/algolia-init-function.ts
+++ b/src/functions/algolia-init-function.ts
@@ -11,7 +11,7 @@ import { Handler } from '@netlify/functions';
 import { DeliveryClient, IContentItem } from '@kontent-ai/delivery-sdk';
 import { canConvertToAlgoliaItem, convertToAlgoliaItem } from './utils/algoliaItem';
 import createAlgoliaClient from 'algoliasearch';
-import { isValidInitRequestBody } from '../shared/types/initRequestBody';
+import { findMissingInitRequestBodyProps, isValidInitRequestBody } from '../shared/types/initRequestBody';
 import { customUserAgent } from "../shared/algoliaUserAgent";
 import { createEnvVars } from './utils/createEnvVars';
 import { serializeUncaughtErrorsHandler } from './utils/serializeUncaughtErrorsHandler';
@@ -26,7 +26,7 @@ export const handler: Handler = serializeUncaughtErrorsHandler(async (event) => 
 
   const body = JSON.parse(event.body || 'null');
   if (!isValidInitRequestBody(body)) {
-    return { statusCode: 400, body: 'Missing or invalid body, please check the documentation' };
+    return { statusCode: 400, body: `Missing or invalid body, the following properties are missing or invalid: ${findMissingInitRequestBodyProps(body).join(', ')}` };
   }
   if (!envVars.ALGOLIA_API_KEY) {
     return { statusCode: 500, body: `${missingEnvVars.join(', ')} environment variable(s) are missing, please check the documentation` };

--- a/src/functions/algolia-init-function.ts
+++ b/src/functions/algolia-init-function.ts
@@ -11,13 +11,13 @@ import { Handler } from '@netlify/functions';
 import { DeliveryClient, IContentItem } from '@kontent-ai/delivery-sdk';
 import { canConvertToAlgoliaItem, convertToAlgoliaItem } from './utils/algoliaItem';
 import createAlgoliaClient from 'algoliasearch';
-import { hasStringProperty, nameOf } from './utils/typeguards';
+import { isValidInitRequestBody } from '../shared/types/initRequestBody';
 import { customUserAgent } from "../shared/algoliaUserAgent";
 import { createEnvVars } from './utils/createEnvVars';
 import { serializeUncaughtErrorsHandler } from './utils/serializeUncaughtErrorsHandler';
 import { sdkHeaders } from "./utils/sdkHeaders";
 
-const { envVars, missingEnvVars } = createEnvVars([ 'ALGOLIA_API_KEY' ] as const)
+const { envVars, missingEnvVars } = createEnvVars(['ALGOLIA_API_KEY'] as const)
 
 export const handler: Handler = serializeUncaughtErrorsHandler(async (event) => {
   if (event.httpMethod !== 'POST') {
@@ -25,7 +25,7 @@ export const handler: Handler = serializeUncaughtErrorsHandler(async (event) => 
   }
 
   const body = JSON.parse(event.body || 'null');
-  if (!isValidBody(body)) {
+  if (!isValidInitRequestBody(body)) {
     return { statusCode: 400, body: 'Missing or invalid body, please check the documentation' };
   }
   if (!envVars.ALGOLIA_API_KEY) {
@@ -36,11 +36,11 @@ export const handler: Handler = serializeUncaughtErrorsHandler(async (event) => 
   const allItems = await getAllContentFromProject(deliverClient, body.language);
   const allItemsMap = new Map(allItems.map(i => [i.system.codename, i]));
   const recordItems = allItems
-    .filter(canConvertToAlgoliaItem(body.slug))
-    .map(convertToAlgoliaItem(allItemsMap, body.slug));
+    .filter(canConvertToAlgoliaItem(body.slugCodename))
+    .map(convertToAlgoliaItem(allItemsMap, body.slugCodename));
 
-  const algoliaClient = createAlgoliaClient(body.appId, envVars.ALGOLIA_API_KEY, { userAgent: customUserAgent });
-  const index = algoliaClient.initIndex(body.index);
+  const algoliaClient = createAlgoliaClient(body.algoliaAppId, envVars.ALGOLIA_API_KEY, { userAgent: customUserAgent });
+  const index = algoliaClient.initIndex(body.algoliaIndexName);
   await index.setSettings({
     searchableAttributes: ['content.contents', 'content.name', 'name'],
     attributesForFaceting: ['content.codename', 'language'],
@@ -61,17 +61,3 @@ const getAllContentFromProject = async (deliverClient: DeliveryClient, languageC
   return [...feed.data.items, ...Object.values(feed.data.linkedItems)];
 };
 
-type BodyConfig = Readonly<{
-  projectId: string;
-  language: string;
-  slug: string;
-  appId: string;
-  index: string;
-}>;
-
-const isValidBody = (body: Record<string, unknown>): body is BodyConfig =>
-  hasStringProperty(nameOf<BodyConfig>('projectId'), body) &&
-  hasStringProperty(nameOf<BodyConfig>('language'), body) &&
-  hasStringProperty(nameOf<BodyConfig>('slug'), body) &&
-  hasStringProperty(nameOf<BodyConfig>('appId'), body) &&
-  hasStringProperty(nameOf<BodyConfig>('index'), body);

--- a/src/shared/constants/readmeSnippets.ts
+++ b/src/shared/constants/readmeSnippets.ts
@@ -1,0 +1,21 @@
+import { Config } from "../../ConfigContext";
+import { InitRequestBody } from "../types/initRequestBody";
+
+// Remember to update readme when you change this file.
+
+export const exampleCustomElementConfig: Config = {
+  language: "{Kontent.ai language codename}",
+  projectId: "{Kontent.ai project ID}",
+  algoliaAppId: "{Algolia app id}",
+  algoliaSearchKey: "{Algolia search-only api key}",
+  algoliaIndexName: "{Algolia index name}",
+  slugCodename: "{Kontent.ai slug codename}",
+};
+
+export const exampleInitRequestBody: InitRequestBody = {
+  language: "{Kontent.ai language codename}",
+  projectId: "{Kontent.ai project ID}",
+  algoliaAppId: "{Algolia app id}",
+  algoliaIndexName: "{Algolia index name}",
+  slugCodename: "{Kontent.ai slug codename}",
+};

--- a/src/shared/types/initRequestBody.ts
+++ b/src/shared/types/initRequestBody.ts
@@ -1,0 +1,17 @@
+import { hasStringProperty, nameOf } from "../utils/typeguards";
+
+export type InitRequestBody = Readonly<{
+  projectId: string;
+  language: string;
+  slugCodename: string;
+  algoliaAppId: string;
+  algoliaIndexName: string;
+}>;
+
+export const isValidInitRequestBody = (body: Record<string, unknown>): body is InitRequestBody =>
+  hasStringProperty(nameOf<InitRequestBody>('projectId'), body) &&
+  hasStringProperty(nameOf<InitRequestBody>('language'), body) &&
+  hasStringProperty(nameOf<InitRequestBody>('slugCodename'), body) &&
+  hasStringProperty(nameOf<InitRequestBody>('algoliaAppId'), body) &&
+  hasStringProperty(nameOf<InitRequestBody>('algoliaIndexName'), body);
+

--- a/src/shared/types/initRequestBody.ts
+++ b/src/shared/types/initRequestBody.ts
@@ -1,4 +1,4 @@
-import { hasStringProperty, nameOf } from "../utils/typeguards";
+import { findMissingStringProps } from "../utils/findMissingStringProps";
 
 export type InitRequestBody = Readonly<{
   projectId: string;
@@ -9,9 +9,16 @@ export type InitRequestBody = Readonly<{
 }>;
 
 export const isValidInitRequestBody = (body: Record<string, unknown>): body is InitRequestBody =>
-  hasStringProperty(nameOf<InitRequestBody>('projectId'), body) &&
-  hasStringProperty(nameOf<InitRequestBody>('language'), body) &&
-  hasStringProperty(nameOf<InitRequestBody>('slugCodename'), body) &&
-  hasStringProperty(nameOf<InitRequestBody>('algoliaAppId'), body) &&
-  hasStringProperty(nameOf<InitRequestBody>('algoliaIndexName'), body);
+  !findMissingStringProps(Object.keys(validRequestBody))(body).length;
+
+const validRequestBody: InitRequestBody = ({
+  projectId: '',
+  language: '',
+  slugCodename: '',
+  algoliaAppId: '',
+  algoliaIndexName: '',
+});
+
+export const findMissingInitRequestBodyProps =
+  findMissingStringProps(Object.keys(validRequestBody));
 

--- a/src/shared/utils/findMissingStringProps.ts
+++ b/src/shared/utils/findMissingStringProps.ts
@@ -1,0 +1,7 @@
+import { hasStringProperty } from "./typeguards";
+
+export const findMissingStringProps = (expectedProps: ReadonlyArray<string>) =>
+  (body: Record<string, unknown> | null): ReadonlyArray<string> =>
+    Object.keys(expectedProps)
+      .filter(key => !hasStringProperty(key, body))
+

--- a/src/shared/utils/typeguards.ts
+++ b/src/shared/utils/typeguards.ts
@@ -1,0 +1,8 @@
+export const hasStringProperty = <PropName extends string, Input extends Record<string, unknown>>(propName: PropName, v: Input): v is Input & { [k in PropName]: string } =>
+  typeof v === 'object' &&
+  v !== null &&
+  v.hasOwnProperty(propName) &&
+  typeof v[propName] === 'string';
+
+export const nameOf = <Shape>(key: keyof Shape) => key;
+

--- a/src/shared/utils/typeguards.ts
+++ b/src/shared/utils/typeguards.ts
@@ -1,4 +1,4 @@
-export const hasStringProperty = <PropName extends string, Input extends Record<string, unknown>>(propName: PropName, v: Input): v is Input & { [k in PropName]: string } =>
+export const hasStringProperty = <PropName extends string, Input extends Record<string, unknown> | null>(propName: PropName, v: Input): v is Input & { [k in PropName]: string } =>
   typeof v === 'object' &&
   v !== null &&
   v.hasOwnProperty(propName) &&


### PR DESCRIPTION
### Motivation

There are some inconsistencies between the settings declared in the readme, the init function and the custom element configuration. This PR synchronizes them.

### Checklist

- [x] Code follows coding conventions held in this repo
- [x] Automated tests have been added
- [x] Tests are passing
- [x] Docs have been updated (if applicable)
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults
