### PR TITLE
Fix findMissingStringProps

### DIFF
--- a/src/shared/utils/findMissingStringProps.ts
+++ b/src/shared/utils/findMissingStringProps.ts
@@ -2,5 +2,5 @@ import { hasStringProperty } from "./typeguards";
 
 export const findMissingStringProps =
   (expectedProps: ReadonlyArray<string>) => (body: Record<string, unknown> | null): ReadonlyArray<string> =>
-    Object.keys(expectedProps)
+    expectedProps
       .filter(key => !hasStringProperty(key, body));


### PR DESCRIPTION
- Don't treat an array like an object

### Motivation

Fixes #17 

